### PR TITLE
Add new `Stack#includes(value)` predicate class method (#3)

### DIFF
--- a/src/stack.js
+++ b/src/stack.js
@@ -16,6 +16,20 @@ class Stack {
     return this;
   }
 
+  includes(value) {
+    let {_head: node} = this;
+
+    while (node) {
+      if (node.data === value) {
+        return true;
+      }
+
+      node = node.next;
+    }
+
+    return false;
+  }
+
   isEmpty() {
     return this._size === 0;
   }

--- a/types/shtack.d.ts
+++ b/types/shtack.d.ts
@@ -6,6 +6,7 @@ declare namespace stack {
   export interface Instance<T> {
     readonly size: number;
     clear(): this;
+    includes(value: T): boolean;
     isEmpty(): boolean;
   }
 }


### PR DESCRIPTION
## Description

The PR introduces the following new unary predicate method: 

- `Stack#includes(value)`

The methods can be used to determine whether the stack includes a value with a certain key, returning `true` or `false` as appropriate.

Also, the corresponding TypeScript ambient declarations are included in the PR.
