### PR TITLE
Add new `Stack#duplicate()` class method (#3)

### DIFF
--- a/src/stack.js
+++ b/src/stack.js
@@ -41,6 +41,18 @@ class Stack {
     return this;
   }
 
+  duplicate() {
+    const {_head} = this;
+
+    if (_head) {
+      const value = this.pop();
+      this.push(value);
+      this.push(value);
+    }
+
+    return this;
+  }
+
   forEach(fn) {
     let {_head: item} = this;
 

--- a/types/shtack.d.ts
+++ b/types/shtack.d.ts
@@ -6,6 +6,7 @@ declare namespace stack {
   export interface Instance<T> {
     readonly size: number;
     clear(): this;
+    duplicate(): this;
     forEach(fn: (x: T) => void): this;
     includes(value: T): boolean;
     isEmpty(): boolean;


### PR DESCRIPTION
## Description

The PR introduces the following new nullary method: 

- `Stack#duplicate()`

Mutates the stack by removing the value located at the top of the stack, and then pushing it twice, so that an additional copy of the former top value is now on top, with the original below it. Returns the stack itself.

Also, the corresponding TypeScript ambient declarations are included in the PR.
